### PR TITLE
feat: changes to cart for fulfillment groups

### DIFF
--- a/src/util/updateCartFulfillmentGroups.js
+++ b/src/util/updateCartFulfillmentGroups.js
@@ -27,6 +27,11 @@ export default function updateCartFulfillmentGroups(context, cart) {
 
   (cart.items || []).forEach((item) => {
     let { supportedFulfillmentTypes } = item;
+    // Do not re-allocate the item if it is already in the group. Otherwise difficult for other code
+    // to create and manage fulfillment groups
+    const itemAlreadyInTheGroup = currentGroups.find(({ itemIds }) => itemIds && itemIds.includes(item._id));
+    if (itemAlreadyInTheGroup) return;
+
     if (!supportedFulfillmentTypes || supportedFulfillmentTypes.length === 0) {
       supportedFulfillmentTypes = ["shipping"];
     }

--- a/src/xforms/xformCartCheckout.js
+++ b/src/xforms/xformCartCheckout.js
@@ -60,7 +60,7 @@ function xformCartFulfillmentGroup(fulfillmentGroup, cart) {
     },
     // For now, we only ever set one fulfillment group, so it has all of the items.
     // Revisit when the UI supports breaking into multiple groups.
-    items: cart.items || [],
+    items: cart.items.filter(({ _id }) => fulfillmentGroup.itemIds.includes(_id)),
     selectedFulfillmentOption,
     shippingAddress: fulfillmentGroup.address,
     shopId: fulfillmentGroup.shopId,


### PR DESCRIPTION
Impact: **minor**
Type: **feature**

## Issue
Every time a cart is transformed, it gets moved to a new fulfillment group making it almost impossible for external code to manipulate that data.

## Solution
If an item is already assigned to a fulfillment group, don't reassign it


## Breaking changes
None


## Testing
There should be no change to current functionality

