### PR TITLE
feat: allow applied cart surcharges to have any shape

### DIFF
--- a/src/simpleSchemas.js
+++ b/src/simpleSchemas.js
@@ -624,51 +624,6 @@ const Money = new SimpleSchema({
   }
 });
 
-const SurchargeMessagesByLanguage = new SimpleSchema({
-  content: String,
-  language: String
-});
-
-/**
- * @name AppliedSurcharge
- * @memberof Schemas
- * @type {SimpleSchema}
- * @property {String} _id
- * @property {Money} amount
- * @property {String} cartId optional
- * @property {String} fulfillmentGroupId optional
- * @property {String} messagesByLanguage optional
- * @property {String} reason optional
- * @property {String} surchargeId optional
- */
-const AppliedSurcharge = new SimpleSchema({
-  "_id": String,
-  "amount": Number,
-  "cartId": {
-    type: String,
-    optional: true
-  },
-  "fulfillmentGroupId": {
-    type: String,
-    optional: true
-  },
-  /*
-   * Message is used as a client message to let customers know why this surcharge might apply
-   * It can be saved in various languages
-  */
-  "messagesByLanguage": {
-    type: Array,
-    optional: true
-  },
-  "messagesByLanguage.$": {
-    type: SurchargeMessagesByLanguage
-  },
-  "surchargeId": {
-    type: String,
-    optional: true
-  }
-});
-
 /**
  * @name CartItemAttribute
  * @memberof Schemas
@@ -886,7 +841,8 @@ export const Cart = new SimpleSchema({
     optional: true
   },
   "surcharges.$": {
-    type: AppliedSurcharge
+    type: Object,
+    blackbox: true
   },
   "workflow": {
     type: Workflow,


### PR DESCRIPTION
Type: **feature**

## Changes
Companion to https://github.com/reactioncommerce/api-plugin-surcharges/pull/3

Applied surcharge fields are no longer validated when being applied to a cart. Any object with any fields is allowed. Responsibility is passed to the `surcharges` plugin to validate before returning them.

This makes it easier for plugins to override the AppliedSurcharge schema, since it is stored by both carts and orders.

## Breaking changes
None

## Testing
Probably easiest to merge after code review and test together with https://github.com/reactioncommerce/api-plugin-surcharges/pull/3