### PR TITLE
Add offset for CartItem productTags & Cart items

### DIFF
--- a/src/schemas/cart.graphql
+++ b/src/schemas/cart.graphql
@@ -42,6 +42,9 @@ type Cart implements Node {
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
 
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
+
     "Return results sorted in this order"
     sortOrder: SortOrder = desc,
 
@@ -198,6 +201,9 @@ type CartItem implements Node {
 
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
 
     "Return results sorted in this order"
     sortOrder: SortOrder = asc,


### PR DESCRIPTION
Signed-off-by: trojanh <rajan.tiwari@kiprosh.com>

Issue: https://github.com/reactioncommerce/reaction/issues/6252
Impact: **minor**
Type: **bugfix**

## Issue
Missing offset params for pagination for CartItem productTags & Cart items
