### PR TITLE
fix: find by _id OR anonymousAccessToken

### DIFF
--- a/src/queries/anonymousCartByCartId.js
+++ b/src/queries/anonymousCartByCartId.js
@@ -19,6 +19,6 @@ export default async function anonymousCartByCartId(context, { cartId, cartToken
   if (!cartId) {
     throw new ReactionError("invalid-param", "You must provide a cartId");
   }
-  
-  return Cart.findOne({$or:[{_id: cartId},{anonymousAccessToken: hashToken(cartToken)}]});
+
+  return Cart.findOne({ $or: [{ _id: cartId }, { anonymousAccessToken: hashToken(cartToken) }] });
 }

--- a/src/queries/anonymousCartByCartId.js
+++ b/src/queries/anonymousCartByCartId.js
@@ -19,9 +19,6 @@ export default async function anonymousCartByCartId(context, { cartId, cartToken
   if (!cartId) {
     throw new ReactionError("invalid-param", "You must provide a cartId");
   }
-
-  return Cart.findOne({
-    _id: cartId,
-    anonymousAccessToken: hashToken(cartToken)
-  });
+  
+  return Cart.findOne({$or:[{_id: cartId},{anonymousAccessToken: hashToken(cartToken)}]});
 }


### PR DESCRIPTION
Signed-off-by: Mohan Narayana <mohan.narayana@mailchimp.com>

Resolves #7 
Impact: **minor**
Type: **bugfix**

## Issue
When querying using anonymousAccessToken from DB the search breaks as the anonymousAccessToken is already hashed in the DB. If either cartId or anonymousAccessToken is wrong, the query returns null.

## Solution
Add **_or_** condition to findOne(). Cart ID is unique in the first place so it should find the right anonymous cart. If cart ID is wrong or cannot find a record then query is tried with anonymousAccessToken. 
NOTE: The anonymousAccessToken stored in browser is not hashed and queries correctly without the or condition for the query parameters.


## Testing
Run the below query before and after pulling the fix.
```
{
  anonymousCartByCartId(cartId:"<cartId>", cartToken:"<anonymousAccessToken>"){
    missingItems{
      title
      productConfiguration{
        productId
        productVariantId
      }
    }
    items{
      nodes{
        title
      _id
      }
    }
  }
}
```

## Expected Result
![image](https://user-images.githubusercontent.com/75854210/138926228-80f285a2-f164-47c4-81f2-8f130de8c71f.png)
