### PR TITLE
fix: use context schema

### DIFF
--- a/src/mutations/transformAndValidateCart.js
+++ b/src/mutations/transformAndValidateCart.js
@@ -2,7 +2,6 @@ import Logger from "@reactioncommerce/logger";
 import forEachPromise from "@reactioncommerce/api-utils/forEachPromise.js";
 import updateCartFulfillmentGroups from "../util/updateCartFulfillmentGroups.js";
 import xformCartGroupToCommonOrder from "../util/xformCartGroupToCommonOrder.js";
-import { Cart as CartSchema } from "../simpleSchemas.js";
 import { cartTransforms } from "../registration.js";
 
 const logCtx = { name: "cart", file: "transformAndValidateCart" };
@@ -15,6 +14,7 @@ const logCtx = { name: "cart", file: "transformAndValidateCart" };
  * @returns {undefined}
  */
 export default async function transformAndValidateCart(context, cart) {
+  const cartSchema = context.simpleSchemas.Cart;
   updateCartFulfillmentGroups(context, cart);
 
   let commonOrders;
@@ -46,5 +46,5 @@ export default async function transformAndValidateCart(context, cart) {
     Logger.debug({ ...logCtx, cartId: cart._id, ms: Date.now() - startTime }, `Finished ${transformInfo.name} cart transform`);
   });
 
-  CartSchema.validate(cart);
+  cartSchema.validate(cart)
 }

--- a/src/mutations/transformAndValidateCart.js
+++ b/src/mutations/transformAndValidateCart.js
@@ -46,5 +46,5 @@ export default async function transformAndValidateCart(context, cart) {
     Logger.debug({ ...logCtx, cartId: cart._id, ms: Date.now() - startTime }, `Finished ${transformInfo.name} cart transform`);
   });
 
-  cartSchema.validate(cart)
+  cartSchema.validate(cart);
 }


### PR DESCRIPTION
Signed-off-by: Mohan Narayana <mohan.narayana@mailchimp.com>

Resolves #16
Impact: **minor**
Type: **bugfix**

## Issue
Schema is directly referenced from simpleSchema.js which could cause validation failure upon extending schema.

## Solution
The schema should be retrieved from the context

## Testing
1. Add items to cart, change quantity and delete. All actions should work without error.
