### PR TITLE
Query with cartId and accessToken. Unit tests.

### DIFF
--- a/src/queries/anonymousCartByCartId.js
+++ b/src/queries/anonymousCartByCartId.js
@@ -20,5 +20,8 @@ export default async function anonymousCartByCartId(context, { cartId, cartToken
     throw new ReactionError("invalid-param", "You must provide a cartId");
   }
 
-  return Cart.findOne({ $or: [{ _id: cartId }, { anonymousAccessToken: hashToken(cartToken) }] });
+  return Cart.findOne({
+    _id: cartId,
+    anonymousAccessToken: hashToken(cartToken)
+  });
 }

--- a/src/queries/anonymousCartByCartId.test.js
+++ b/src/queries/anonymousCartByCartId.test.js
@@ -24,17 +24,14 @@ test("query anonymous cart", async () => {
 test("query without hashed access token", async () => {
   const cartId = "123";
   const cartToken = "xyz";
-  const cart = {
+  const callingParams = {
     _id: cartId,
     anonymousAccessToken: cartToken
   };
-  const callingParams = {
-    _id: cartId,
-    anonymousAccessToken: (cartToken)
-  };
 
-  mockContext.collections.Cart.findOne.mockReturnValueOnce(Promise.resolve(cart));
+  mockContext.collections.Cart.findOne.mockReturnValueOnce(Promise.resolve(null));
 
-  await anonymousCartByCartId(mockContext, { cartId, cartToken });
+  const result = await anonymousCartByCartId(mockContext, { cartId, cartToken });
+  expect(result).toEqual(null);
   expect(mockContext.collections.Cart.findOne).not.toHaveBeenCalledWith(callingParams);
 });

--- a/src/queries/anonymousCartByCartId.test.js
+++ b/src/queries/anonymousCartByCartId.test.js
@@ -5,18 +5,36 @@ import anonymousCartByCartId from "./anonymousCartByCartId.js";
 test("query anonymous cart", async () => {
   const cartId = "123";
   const cartToken = "xyz";
-  const cart = { 
-      _id: cartId,
-      anonymousAccessToken: cartToken
-    };
+  const cart = {
+    _id: cartId,
+    anonymousAccessToken: cartToken
+  };
   const callingParams = {
-      _id: cartId,
-      anonymousAccessToken: hashToken(cartToken)
-    };
+    _id: cartId,
+    anonymousAccessToken: hashToken(cartToken)
+  };
 
   mockContext.collections.Cart.findOne.mockReturnValueOnce(Promise.resolve(cart));
 
   const result = await anonymousCartByCartId(mockContext, { cartId, cartToken });
   expect(result).toEqual(cart);
   expect(mockContext.collections.Cart.findOne).toHaveBeenCalledWith(callingParams);
+});
+
+test("query without hashed access token", async () => {
+  const cartId = "123";
+  const cartToken = "xyz";
+  const cart = {
+    _id: cartId,
+    anonymousAccessToken: cartToken
+  };
+  const callingParams = {
+    _id: cartId,
+    anonymousAccessToken: (cartToken)
+  };
+
+  mockContext.collections.Cart.findOne.mockReturnValueOnce(Promise.resolve(cart));
+
+  await anonymousCartByCartId(mockContext, { cartId, cartToken });
+  expect(mockContext.collections.Cart.findOne).not.toHaveBeenCalledWith(callingParams);
 });

--- a/src/queries/anonymousCartByCartId.test.js
+++ b/src/queries/anonymousCartByCartId.test.js
@@ -1,0 +1,22 @@
+import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
+import hashToken from "@reactioncommerce/api-utils/hashToken.js";
+import anonymousCartByCartId from "./anonymousCartByCartId.js";
+
+test("query anonymous cart", async () => {
+  const cartId = "123";
+  const cartToken = "xyz";
+  const cart = { 
+      _id: cartId,
+      anonymousAccessToken: cartToken
+    };
+  const callingParams = {
+      _id: cartId,
+      anonymousAccessToken: hashToken(cartToken)
+    };
+
+  mockContext.collections.Cart.findOne.mockReturnValueOnce(Promise.resolve(cart));
+
+  const result = await anonymousCartByCartId(mockContext, { cartId, cartToken });
+  expect(result).toEqual(cart);
+  expect(mockContext.collections.Cart.findOne).toHaveBeenCalledWith(callingParams);
+});


### PR DESCRIPTION
Signed-off-by: Mohan Narayana <mohan.narayana@mailchimp.com>

Resolves #33 
Impact: **minor**
Type: **bugfix|refactor**

## Issue
The or condition used to query anonymousCartByCartId ignores the access token. 

## Solution
Revert the query.

Note: The access token is to provide secure access but is not implemented in carts.

## Testing
Run the below query with values from browser Local Storage

```
{
  anonymousCartByCartId(cartId:<anonymousCartId>, cartToken:<anonymousCartToken>){
    missingItems{
      title
      productConfiguration{
        productId
        productVariantId
      }
    }
    items{
      nodes{
        productConfiguration{
          productId
          productVariantId
        }
      
      }
    }
  }
}
```

