### PR TITLE
fix: adds tags as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "semantic-release": "^17.4.7"
   },
   "peerDependencies": {
-    "@reactioncommerce/api-plugin-address-validation": "^1.0.0"
+    "@reactioncommerce/api-plugin-address-validation": "^1.0.0",
+    "@reactioncommerce/api-plugin-tags": "^1.0.0"
   },
   "scripts": {
     "lint": "npm run lint:eslint",


### PR DESCRIPTION
Signed-off-by: Sujith <sujith@merchstack.com>

Resolves #4 
Impact: **minor**
Type: **chore**

## Issue
Issue as mentioned in the ticket- Carts uses the TagSortByField and TagConnection type in GraphQL, which lives in the tags plugin. When work is done to move carts over here, we need to be sure to install api-plugin-tags as a peerDependency.

## Solution
Just to ensure we are on same page, I am adding my understanding regarding peerDependency
An entry in peerDependency object of a plugin does NOT get installed by npm automatically. The entries has to be explicitly added as a dependency in the main package which is using the plugin and peerDependency gives out a warning if it is not done. Usually peerDependency is used in custom packages/plugins when a plugin works only with a specific version of a host package but if we are using a different version of the host package and add this plugin, then it generates a warning.

After updating the package.json, both "npm install" and "reaction develop" completed successfully.

## Breaking changes
None.

## Note
Noticed that the api-tags-plugin is using a function declared preStartup which is already declared in authorization-simple plugin.

## Testing
After updating the package.json, pointed the cart-plugin to the updated version inside a new project and executed both "npm install" and "reaction develop". Both completed successfully.
